### PR TITLE
Engine: block auth-skipping recognition on untrusted IPs

### DIFF
--- a/docs/content/configuration/providers/index.mdx
+++ b/docs/content/configuration/providers/index.mdx
@@ -80,13 +80,12 @@ If this is absent, Identica uses `settings.connection.sessions.concurrencyPolicy
 
 - Takes: `true` or `false`
 - Current default: `false`
-- Affects: whether this provider may still use automatic reconnect recognition from IPs blocked by `settings.connection.sessions.recognition.untrustedIps`
+- Affects: whether this provider may use recognition-based authentication bypass from IPs blocked by `settings.connection.sessions.recognition.untrustedIps`
 
 Leave this `false` for the normal safety posture.
-Set it to `true` only when a specific provider should remain auto-recognizable even from client IPs you otherwise distrust for reconnect recognition.
+Set it to `true` only when a specific provider may skip authentication from client IPs that are blocked for recognition by default.
 
-This override restores automatic recognition only for that provider.
-It does not affect explicit manual or entrypoint-driven provider usage because those flows are not suppressed by the untrusted-IP guard.
+This override applies only to that provider.
 
 #### overrides.recognition.enabled
 

--- a/docs/content/configuration/settings/index.mdx
+++ b/docs/content/configuration/settings/index.mdx
@@ -547,10 +547,9 @@ Enable recognition only if you understand that tradeoff and accept the risk for 
 
 - Takes: `true` or `false`
 - Current default: `true`
-- Affects: whether automatic reconnect recognition is suppressed for configured client IPs and CIDR ranges
+- Affects: whether recognition-based authentication bypass is allowed for configured client IPs and CIDR ranges
 
-This guard only affects automatic provider recognition.
-It does not block explicit provider usage through entrypoint-selected or manually selected providers.
+This guard controls recognition paths that can skip provider authentication, including reconnect recognition and provider-scoped handshake or session recognition.
 
 Use this when reconnect recognition is generally acceptable, but there are client networks you do not trust for automatic recognition decisions.
 The generated defaults target the common “proxy forwarded a loopback/private proxy IP instead of the real client IP” failure mode.
@@ -561,7 +560,7 @@ The generated defaults target the common “proxy forwarded a loopback/private p
 
 - Takes: a list of exact IP literals or IPv4/IPv6 CIDR ranges
 - Current default: `["127.0.0.1", "::1", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]`
-- Affects: which client IPs suppress automatic reconnect recognition
+- Affects: which client IPs disable recognition-based authentication bypass
 
 The generated defaults cover loopback and RFC1918 private ranges, which are often a sign that Identica is behind a proxy that is forwarding the wrong source IP.
 

--- a/identica-common/src/main/java/me/whereareiam/identica/common/identity/session/recognition/DefaultSessionRecognitionService.java
+++ b/identica-common/src/main/java/me/whereareiam/identica/common/identity/session/recognition/DefaultSessionRecognitionService.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import me.whereareiam.identica.identity.actor.ConnectionIdentity;
 import me.whereareiam.identica.identity.session.recognition.SessionRecognitionService;
 import me.whereareiam.identica.identity.session.recognition.SessionRecognitionStore;
+import me.whereareiam.identica.identity.session.recognition.policy.UntrustedIpRecognitionPolicy;
 import me.whereareiam.identica.model.config.Providers;
 import me.whereareiam.identica.model.config.Settings;
 import me.whereareiam.identica.model.session.SessionRecognitionSnapshot;
@@ -25,6 +26,7 @@ public class DefaultSessionRecognitionService implements SessionRecognitionServi
 	private final Provider<Settings> settingsProvider;
 	private final Provider<Providers> providersProvider;
 	private final SessionRecognitionStore sessionRecognitionStore;
+	private final UntrustedIpRecognitionPolicy untrustedIpRecognitionPolicy;
 
 	@Override
 	public boolean matches(
@@ -36,6 +38,8 @@ public class DefaultSessionRecognitionService implements SessionRecognitionServi
 	) {
 		if (isBlank(providerId) || isBlank(providerSubject) || !isRecognitionEnabled(providerId))
 			return false;
+		if (untrustedIpRecognitionPolicy.evaluateAutomaticRecognition(providerId, ip, null).isBlocked())
+			return false;
 
 		Optional<SessionRecognitionSnapshot> storedOptional = sessionRecognitionStore.find(providerId.trim(), providerSubject.trim());
 		if (storedOptional.isEmpty()) return false;
@@ -45,6 +49,7 @@ public class DefaultSessionRecognitionService implements SessionRecognitionServi
 			if (!matchesSignal(signal, stored, providerUsername, ip, origin))
 				return false;
 		}
+
 		return true;
 	}
 

--- a/identica-common/src/main/java/me/whereareiam/identica/common/provider/DefaultProviderOperations.java
+++ b/identica-common/src/main/java/me/whereareiam/identica/common/provider/DefaultProviderOperations.java
@@ -6,9 +6,6 @@ import com.google.inject.Singleton;
 import lombok.RequiredArgsConstructor;
 import me.whereareiam.identica.event.EventManager;
 import me.whereareiam.identica.event.provider.ProviderEligibilityEvent;
-import me.whereareiam.identica.identity.session.recognition.policy.UntrustedIpRecognitionDecision;
-import me.whereareiam.identica.identity.session.recognition.policy.UntrustedIpRecognitionPolicy;
-import me.whereareiam.identica.logging.Logger;
 import me.whereareiam.identica.model.config.Providers;
 import me.whereareiam.identica.model.pipeline.journey.JourneyPlan;
 import me.whereareiam.identica.model.pipeline.journey.stage.step.JourneyStep;
@@ -50,7 +47,6 @@ public class DefaultProviderOperations implements ProviderOperations {
 	private final MigrationJourneyRegistry migrationJourneyRegistry;
 	private final Provider<Providers> providersProvider;
 	private final EventManager eventManager;
-	private final UntrustedIpRecognitionPolicy untrustedIpRecognitionPolicy;
 
 	@Override
 	public @Nullable ProfileResolution resolveProfile(@NotNull ProfileResolveContext context) {
@@ -201,7 +197,6 @@ public class DefaultProviderOperations implements ProviderOperations {
 		if (descriptor == null || isBlank(descriptor.getId())) return false;
 		if (!supportsJourney(context, provider, pipelineType, journeyMode)) return false;
 		if (!resolversAllow(context, provider, journeyMode)) return false;
-		if (blocksAutomaticRecognition(context, descriptor.getId())) return false;
 
 		ProviderEligibilityEvent event = new ProviderEligibilityEvent(context, provider, journeyMode);
 		eventManager.call(event);
@@ -256,23 +251,6 @@ public class DefaultProviderOperations implements ProviderOperations {
 			if (!resolver.isEligible(context, provider, journeyMode)) return false;
 		}
 
-		return true;
-	}
-
-	private boolean blocksAutomaticRecognition(@NotNull ScenarioContext context, @NotNull String providerId) {
-		UntrustedIpRecognitionDecision decision = untrustedIpRecognitionPolicy.evaluateAutomaticRecognition(
-				providerId,
-				context.getIp(),
-				context.getProvider()
-		);
-		if (!decision.isBlocked()) return false;
-		Logger.debug(
-				"Skipping automatic provider recognition provider=%s username=%s ip=%s outcome=%s",
-				providerId,
-				context.getUsername(),
-				context.getIp(),
-				decision.getOutcome()
-		);
 		return true;
 	}
 

--- a/identica-common/src/test/java/me/whereareiam/identica/common/conflict/guard/UsernameEntrypointConflictGuardTest.java
+++ b/identica-common/src/test/java/me/whereareiam/identica/common/conflict/guard/UsernameEntrypointConflictGuardTest.java
@@ -3,7 +3,6 @@ package me.whereareiam.identica.common.conflict.guard;
 import me.whereareiam.identica.common.config.defaults.messages.MessagesDefaults;
 import me.whereareiam.identica.common.provider.DefaultProviderOperations;
 import me.whereareiam.identica.event.EventManager;
-import me.whereareiam.identica.identity.session.recognition.policy.UntrustedIpRecognitionPolicy;
 import me.whereareiam.identica.model.config.Messages;
 import me.whereareiam.identica.model.config.Providers;
 import me.whereareiam.identica.model.conflict.ConflictContext;
@@ -39,8 +38,6 @@ class UsernameEntrypointConflictGuardTest {
 	private MigrationJourneyRegistry migrationJourneyRegistry;
 	@Mock
 	private EventManager eventManager;
-	@Mock
-	private UntrustedIpRecognitionPolicy untrustedIpRecognitionPolicy;
 
 	@DisplayName("Denies the conflict when the entrypoint was auto-detected and remains ambiguous")
 	@Test
@@ -127,8 +124,7 @@ class UsernameEntrypointConflictGuardTest {
 				registrationJourneyRegistry,
 				migrationJourneyRegistry,
 				() -> providers,
-				eventManager,
-				untrustedIpRecognitionPolicy
+				eventManager
 		);
 	}
 }

--- a/identica-common/src/test/java/me/whereareiam/identica/common/identity/session/recognition/DefaultSessionRecognitionServiceTest.java
+++ b/identica-common/src/test/java/me/whereareiam/identica/common/identity/session/recognition/DefaultSessionRecognitionServiceTest.java
@@ -1,0 +1,138 @@
+package me.whereareiam.identica.common.identity.session.recognition;
+
+import me.whereareiam.identica.common.identity.session.recognition.policy.UntrustedIpRecognitionGuard;
+import me.whereareiam.identica.identity.actor.ConnectionIdentity;
+import me.whereareiam.identica.identity.session.recognition.SessionRecognitionStore;
+import me.whereareiam.identica.model.config.Providers;
+import me.whereareiam.identica.model.config.Settings;
+import me.whereareiam.identica.model.session.SessionRecognitionSnapshot;
+import me.whereareiam.identica.type.session.RecognitionSignal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("Default Session Recognition Service")
+class DefaultSessionRecognitionServiceTest {
+	@DisplayName("Blocks provider recognition on an untrusted IP even when the stored snapshot matches")
+	@Test
+	void blocksRecognitionOnUntrustedIp() {
+		Settings settings = settings(List.of(RecognitionSignal.USERNAME, RecognitionSignal.IP), List.of("127.0.0.1"));
+		Providers providers = providers(false);
+		SessionRecognitionStore store = store(snapshot("127.0.0.1", null, null));
+
+		DefaultSessionRecognitionService service = service(settings, providers, store);
+
+		assertFalse(service.matches("credential", "subject-1", "whereareiam", "127.0.0.1", null));
+	}
+
+	@DisplayName("Allows provider recognition on an untrusted IP when the provider override is enabled")
+	@Test
+	void allowsRecognitionOnUntrustedIpWhenProviderOverrideEnabled() {
+		Settings settings = settings(List.of(RecognitionSignal.USERNAME, RecognitionSignal.IP), List.of("127.0.0.1"));
+		Providers providers = providers(true);
+		SessionRecognitionStore store = store(snapshot("127.0.0.1", null, null));
+
+		DefaultSessionRecognitionService service = service(settings, providers, store);
+
+		assertTrue(service.matches("credential", "subject-1", "whereareiam", "127.0.0.1", null));
+	}
+
+	@DisplayName("Keeps trusted IP recognition working for matching snapshots")
+	@Test
+	void keepsTrustedIpRecognitionWorking() {
+		Settings settings = settings(
+				List.of(RecognitionSignal.USERNAME, RecognitionSignal.IP, RecognitionSignal.VIRTUAL_HOST),
+				List.of("127.0.0.1")
+		);
+		Providers providers = providers(false);
+		SessionRecognitionStore store = store(snapshot("203.0.113.10", "localhost", 25565));
+
+		DefaultSessionRecognitionService service = service(settings, providers, store);
+
+		assertTrue(service.matches(
+				"credential",
+				"subject-1",
+				"whereareiam",
+				"203.0.113.10",
+				new ConnectionIdentity.Origin("localhost", 25565)
+		));
+	}
+
+	private DefaultSessionRecognitionService service(
+			Settings settings,
+			Providers providers,
+			SessionRecognitionStore store
+	) {
+		return new DefaultSessionRecognitionService(
+				() -> settings,
+				() -> providers,
+				store,
+				new UntrustedIpRecognitionGuard(() -> settings, () -> providers)
+		);
+	}
+
+	private SessionRecognitionStore store(SessionRecognitionSnapshot snapshot) {
+		SessionRecognitionStore store = mock(SessionRecognitionStore.class);
+		when(store.find(snapshot.getProviderId(), snapshot.getProviderSubject())).thenReturn(Optional.of(snapshot));
+		return store;
+	}
+
+	private Settings settings(
+			List<RecognitionSignal> signals,
+			List<String> untrustedIps
+	) {
+		Settings.Sessions.Recognition.UntrustedIps untrusted = new Settings.Sessions.Recognition.UntrustedIps();
+		untrusted.setEnabled(true);
+		untrusted.setEntries(untrustedIps);
+
+		Settings.Sessions.Recognition recognition = new Settings.Sessions.Recognition();
+		recognition.setEnabled(true);
+		recognition.setValidity(Duration.ofHours(12));
+		recognition.setDefaultSignals(signals);
+		recognition.setUntrustedIps(untrusted);
+
+		Settings.Sessions sessions = new Settings.Sessions();
+		sessions.setRecognition(recognition);
+
+		Settings.Connection connection = new Settings.Connection();
+		connection.setSessions(sessions);
+
+		Settings settings = new Settings();
+		settings.setConnection(connection);
+		return settings;
+	}
+
+	private Providers providers(boolean allowRecognitionOnUntrustedIp) {
+		Providers.ProviderEntry provider = new Providers.ProviderEntry();
+		provider.setId("credential");
+		provider.getOverrides().setAllowRecognitionOnUntrustedIp(allowRecognitionOnUntrustedIp);
+
+		Providers providers = new Providers();
+		providers.setProviders(List.of(provider));
+		return providers;
+	}
+
+	private SessionRecognitionSnapshot snapshot(
+			String lastIp,
+			String lastVirtualHost,
+			Integer lastVirtualPort
+	) {
+		return SessionRecognitionSnapshot.builder()
+				.providerId("credential")
+				.providerSubject("subject-1")
+				.providerUsername("whereareiam")
+				.lastIp(lastIp)
+				.lastVirtualHost(lastVirtualHost)
+				.lastVirtualPort(lastVirtualPort)
+				.capturedAt(System.currentTimeMillis())
+				.build();
+	}
+}

--- a/identica-common/src/test/java/me/whereareiam/identica/common/provider/DefaultProviderOperationsTest.java
+++ b/identica-common/src/test/java/me/whereareiam/identica/common/provider/DefaultProviderOperationsTest.java
@@ -2,8 +2,6 @@ package me.whereareiam.identica.common.provider;
 
 import me.whereareiam.identica.event.EventManager;
 import me.whereareiam.identica.identity.actor.ConnectionIdentity;
-import me.whereareiam.identica.identity.session.recognition.policy.UntrustedIpRecognitionDecision;
-import me.whereareiam.identica.identity.session.recognition.policy.UntrustedIpRecognitionPolicy;
 import me.whereareiam.identica.model.config.Providers;
 import me.whereareiam.identica.model.pipeline.ScenarioTransitionItem;
 import me.whereareiam.identica.model.pipeline.journey.JourneyPlan;
@@ -25,7 +23,6 @@ import me.whereareiam.identica.type.pipeline.PipelineType;
 import me.whereareiam.identica.type.pipeline.journey.JourneyMode;
 import me.whereareiam.identica.type.pipeline.journey.StageType;
 import me.whereareiam.identica.type.pipeline.journey.step.StepContextRequirement;
-import me.whereareiam.identica.type.provider.ProviderOrigin;
 import me.whereareiam.identica.type.provider.ProviderState;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.DisplayName;
@@ -56,8 +53,6 @@ class DefaultProviderOperationsTest {
 	private MigrationJourneyRegistry migrationJourneyRegistry;
 	@Mock
 	private EventManager eventManager;
-	@Mock
-	private UntrustedIpRecognitionPolicy untrustedIpRecognitionPolicy;
 
 	@DisplayName("Matches entrypoints by host name regardless of case")
 	@Test
@@ -137,71 +132,16 @@ class DefaultProviderOperationsTest {
 		assertEquals("Alpha Provider", operations.displayProviderName("alpha"));
 	}
 
-	@DisplayName("Suppresses automatic provider eligibility when untrusted IP recognition blocks it")
+	@DisplayName("Keeps automatic provider eligibility on untrusted IPs")
 	@Test
-	void suppressesAutomaticEligibilityOnUntrustedIp() {
+	void keepsAutomaticEligibilityOnUntrustedIp() {
 		Providers providers = new Providers();
 		providers.setProviders(List.of(entry("alpha", 10, List.of("play.example.com"))));
 
-		InternalProvider provider = enabledProvider("alpha");
+		InternalProvider provider = enabledProvider();
 		when(authenticationJourneyRegistry.resolvePlan(any(), any(), any(), any())).thenReturn(providerPlan());
-		when(untrustedIpRecognitionPolicy.evaluateAutomaticRecognition(
-				org.mockito.ArgumentMatchers.eq("alpha"),
-				org.mockito.ArgumentMatchers.eq("127.0.0.1"),
-				org.mockito.ArgumentMatchers.isNull()
-		)).thenReturn(blockedDecision());
 
-		assertFalse(operations(providers).isEligible(autoContext(), provider, PipelineType.AUTHENTICATION, JourneyMode.INTERACTIVE));
-	}
-
-	@DisplayName("Keeps explicit provider selection eligible on untrusted IP")
-	@Test
-	void keepsExplicitSelectionEligibleOnUntrustedIp() {
-		Providers providers = new Providers();
-		providers.setProviders(List.of(entry("alpha", 10, List.of("play.example.com"))));
-
-		InternalProvider provider = enabledProvider("alpha");
-		when(authenticationJourneyRegistry.resolvePlan(any(), any(), any(), any())).thenReturn(providerPlan());
-		when(untrustedIpRecognitionPolicy.evaluateAutomaticRecognition(
-				org.mockito.ArgumentMatchers.eq("alpha"),
-				org.mockito.ArgumentMatchers.eq("127.0.0.1"),
-				any()
-		)).thenReturn(allowedDecision());
-
-		assertTrue(operations(providers).isEligible(
-				context(ProviderContext.of("alpha", null, "PlayerOne", ProviderOrigin.MANUAL)),
-				provider,
-				PipelineType.AUTHENTICATION,
-				JourneyMode.INTERACTIVE
-		));
-	}
-
-	@DisplayName("Restores automatic recognition only for providers with the override")
-	@Test
-	void providerOverrideRestoresRecognitionOnlyForMatchingProvider() {
-		Providers providers = new Providers();
-		Providers.ProviderEntry alpha = entry("alpha", 10, List.of("alpha.example.com"));
-		alpha.getOverrides().setAllowRecognitionOnUntrustedIp(true);
-		Providers.ProviderEntry beta = entry("beta", 10, List.of("beta.example.com"));
-		providers.setProviders(List.of(alpha, beta));
-
-		InternalProvider alphaProvider = enabledProvider("alpha");
-		InternalProvider betaProvider = enabledProvider("beta");
-		when(authenticationJourneyRegistry.resolvePlan(any(), any(), any(), any())).thenReturn(providerPlan());
-		when(untrustedIpRecognitionPolicy.evaluateAutomaticRecognition(
-				org.mockito.ArgumentMatchers.eq("alpha"),
-				org.mockito.ArgumentMatchers.eq("127.0.0.1"),
-				org.mockito.ArgumentMatchers.isNull()
-		)).thenReturn(allowedDecision());
-		when(untrustedIpRecognitionPolicy.evaluateAutomaticRecognition(
-				org.mockito.ArgumentMatchers.eq("beta"),
-				org.mockito.ArgumentMatchers.eq("127.0.0.1"),
-				org.mockito.ArgumentMatchers.isNull()
-		)).thenReturn(blockedDecision());
-
-		ProviderOperations operations = operations(providers);
-		assertTrue(operations.isEligible(autoContext(), alphaProvider, PipelineType.AUTHENTICATION, JourneyMode.INTERACTIVE));
-		assertFalse(operations.isEligible(autoContext(), betaProvider, PipelineType.AUTHENTICATION, JourneyMode.INTERACTIVE));
+		assertTrue(operations(providers).isEligible(autoContext(), provider, PipelineType.AUTHENTICATION, JourneyMode.INTERACTIVE));
 	}
 
 	private ProviderOperations operations(Providers providers) {
@@ -211,8 +151,7 @@ class DefaultProviderOperationsTest {
 				registrationJourneyRegistry,
 				migrationJourneyRegistry,
 				() -> providers,
-				eventManager,
-				untrustedIpRecognitionPolicy
+				eventManager
 		);
 	}
 
@@ -224,9 +163,9 @@ class DefaultProviderOperationsTest {
 		return entry;
 	}
 
-	private InternalProvider enabledProvider(String id) {
+	private InternalProvider enabledProvider() {
 		ProviderDescriptor descriptor = new ProviderDescriptor();
-		descriptor.setId(id);
+		descriptor.setId("alpha");
 		return InternalProvider.builder()
 				.descriptor(descriptor)
 				.priority(10)
@@ -234,25 +173,13 @@ class DefaultProviderOperationsTest {
 				.build();
 	}
 
-	private UntrustedIpRecognitionDecision allowedDecision() {
-		return new UntrustedIpRecognitionDecision(
-				UntrustedIpRecognitionDecision.Outcome.ALLOWED_IP_NOT_MATCHED
-		);
-	}
-
-	private UntrustedIpRecognitionDecision blockedDecision() {
-		return new UntrustedIpRecognitionDecision(
-				UntrustedIpRecognitionDecision.Outcome.BLOCKED_UNTRUSTED_IP
-		);
-	}
-
 	private ScenarioContext autoContext() {
-		return context(null);
+		return context();
 	}
 
-	private ScenarioContext context(ProviderContext provider) {
+	private ScenarioContext context() {
 		return new ScenarioContext() {
-			private ProviderContext currentProvider = provider;
+			private ProviderContext currentProvider = null;
 
 			@Override
 			public @NotNull ConnectionIdentity getIdentity() {


### PR DESCRIPTION
Fixes #74 