### PR TITLE
feat: add command blocker

### DIFF
--- a/identica-adapter-command/src/main/java/me/whereareiam/identica/adapter/command/CommandConfiguration.java
+++ b/identica-adapter-command/src/main/java/me/whereareiam/identica/adapter/command/CommandConfiguration.java
@@ -1,11 +1,13 @@
 package me.whereareiam.identica.adapter.command;
 
 import com.google.inject.AbstractModule;
+import me.whereareiam.identica.command.CommandDefinitionCollector;
 import me.whereareiam.identica.command.CommandService;
 
 public class CommandConfiguration extends AbstractModule {
 	@Override
 	protected void configure() {
 		bind(CommandService.class).to(DefaultCommandService.class).asEagerSingleton();
+		bind(CommandDefinitionCollector.class).to(DefaultCommandDefinitionCollector.class).asEagerSingleton();
 	}
 }

--- a/identica-adapter-command/src/main/java/me/whereareiam/identica/adapter/command/DefaultCommandDefinitionCollector.java
+++ b/identica-adapter-command/src/main/java/me/whereareiam/identica/adapter/command/DefaultCommandDefinitionCollector.java
@@ -1,0 +1,55 @@
+package me.whereareiam.identica.adapter.command;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.whereareiam.identica.command.CommandDefinitionCollector;
+import me.whereareiam.identica.command.CommandService;
+import me.whereareiam.identica.model.CommandDefinition;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+@Singleton
+public class DefaultCommandDefinitionCollector implements CommandDefinitionCollector {
+	private final CommandService commandService;
+	private volatile Set<String> cachedAliases = null;
+
+	@Inject
+	public DefaultCommandDefinitionCollector(CommandService commandService) {
+		this.commandService = commandService;
+	}
+
+	@Override
+	public @NotNull Set<String> getAllowedDuringAuthAliases() {
+		Set<String> local = cachedAliases;
+		if (local != null)
+			return local;
+
+		synchronized (this) {
+			local = cachedAliases;
+			if (local != null)
+				return local;
+
+			Map<String, CommandDefinition> definitions = commandService.getRegisteredDefinitions();
+			Set<String> aliases = new HashSet<>();
+			for (Map.Entry<String, CommandDefinition> entry : definitions.entrySet()) {
+				CommandDefinition def = entry.getValue();
+				if (def.getAliases() == null)
+					continue;
+
+				if (def.isAllowedDuringAuth() || "main".equals(entry.getKey()))
+					aliases.addAll(def.getAliases());
+			}
+
+			cachedAliases = Collections.unmodifiableSet(aliases);
+			return cachedAliases;
+		}
+	}
+
+	public void invalidateCache() {
+		cachedAliases = null;
+	}
+}

--- a/identica-adapter-command/src/test/java/me/whereareiam/identica/adapter/command/DefaultCommandDefinitionCollectorTest.java
+++ b/identica-adapter-command/src/test/java/me/whereareiam/identica/adapter/command/DefaultCommandDefinitionCollectorTest.java
@@ -1,0 +1,113 @@
+package me.whereareiam.identica.adapter.command;
+
+import me.whereareiam.identica.command.CommandService;
+import me.whereareiam.identica.model.CommandDefinition;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("Default Command Definition Collector")
+class DefaultCommandDefinitionCollectorTest {
+	private final CommandService commandService = mock(CommandService.class);
+	private final DefaultCommandDefinitionCollector collector = new DefaultCommandDefinitionCollector(commandService);
+
+	@DisplayName("Returns empty set when no definitions are allowed during auth")
+	@Test
+	void returnsEmptySetWhenNoneAllowed() {
+		CommandDefinition def = CommandDefinition.builder()
+				.aliases(List.of("tp", "teleport"))
+				.allowedDuringAuth(false)
+				.build();
+		when(commandService.getRegisteredDefinitions()).thenReturn(Map.of("teleport", def));
+
+		assertTrue(collector.getAllowedDuringAuthAliases().isEmpty());
+	}
+
+	@DisplayName("Returns aliases from definitions marked as allowedDuringAuth")
+	@Test
+	void returnsAllowedAliases() {
+		CommandDefinition login = CommandDefinition.builder()
+				.aliases(List.of("login", "l"))
+				.allowedDuringAuth(true)
+				.build();
+		CommandDefinition tp = CommandDefinition.builder()
+				.aliases(List.of("tp"))
+				.allowedDuringAuth(false)
+				.build();
+		when(commandService.getRegisteredDefinitions()).thenReturn(Map.of("login", login, "tp", tp));
+
+		Set<String> aliases = collector.getAllowedDuringAuthAliases();
+
+		assertEquals(Set.of("login", "l"), aliases);
+	}
+
+	@DisplayName("Caches result on subsequent calls")
+	@Test
+	void cachesResult() {
+		CommandDefinition def = CommandDefinition.builder()
+				.aliases(List.of("login"))
+				.allowedDuringAuth(true)
+				.build();
+		when(commandService.getRegisteredDefinitions()).thenReturn(Map.of("login", def));
+
+		Set<String> first = collector.getAllowedDuringAuthAliases();
+		Set<String> second = collector.getAllowedDuringAuthAliases();
+
+		assertSame(first, second);
+	}
+
+	@DisplayName("Invalidates cache when invalidateCache is called")
+	@Test
+	void invalidatesCache() {
+		CommandDefinition def = CommandDefinition.builder()
+				.aliases(List.of("login"))
+				.allowedDuringAuth(true)
+				.build();
+		when(commandService.getRegisteredDefinitions()).thenReturn(Map.of("login", def));
+
+		collector.getAllowedDuringAuthAliases();
+		collector.invalidateCache();
+
+		when(commandService.getRegisteredDefinitions()).thenReturn(Map.of(
+				"login", def,
+				"register", CommandDefinition.builder()
+						.aliases(List.of("register"))
+						.allowedDuringAuth(true)
+						.build()
+		));
+
+		assertEquals(Set.of("login", "register"), collector.getAllowedDuringAuthAliases());
+	}
+
+	@DisplayName("Returns unmodifiable set")
+	@Test
+	void returnsUnmodifiableSet() {
+		CommandDefinition def = CommandDefinition.builder()
+				.aliases(List.of("login"))
+				.allowedDuringAuth(true)
+				.build();
+		when(commandService.getRegisteredDefinitions()).thenReturn(Map.of("login", def));
+
+		Set<String> aliases = collector.getAllowedDuringAuthAliases();
+
+		assertThrows(UnsupportedOperationException.class, () -> aliases.add("newalias"));
+	}
+
+	@DisplayName("Ignores definitions with null aliases")
+	@Test
+	void ignoresNullAliases() {
+		CommandDefinition def = CommandDefinition.builder()
+				.allowedDuringAuth(true)
+				.build();
+		when(commandService.getRegisteredDefinitions()).thenReturn(Map.of("test", def));
+
+		assertTrue(collector.getAllowedDuringAuthAliases().isEmpty());
+	}
+}

--- a/identica-api/src/main/java/me/whereareiam/identica/command/CommandDefinitionCollector.java
+++ b/identica-api/src/main/java/me/whereareiam/identica/command/CommandDefinitionCollector.java
@@ -1,0 +1,10 @@
+package me.whereareiam.identica.command;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Set;
+
+@SuppressWarnings("unused")
+public interface CommandDefinitionCollector {
+	@NotNull Set<String> getAllowedDuringAuthAliases();
+}

--- a/identica-api/src/main/java/me/whereareiam/identica/command/CommandFilterService.java
+++ b/identica-api/src/main/java/me/whereareiam/identica/command/CommandFilterService.java
@@ -1,0 +1,9 @@
+package me.whereareiam.identica.command;
+
+import me.whereareiam.keystone.Actor;
+import org.jetbrains.annotations.NotNull;
+
+@SuppressWarnings("unused")
+public interface CommandFilterService {
+	boolean isAllowed(@NotNull Actor sender, @NotNull String commandLine);
+}

--- a/identica-api/src/main/java/me/whereareiam/identica/model/CommandDefinition.java
+++ b/identica-api/src/main/java/me/whereareiam/identica/model/CommandDefinition.java
@@ -29,6 +29,9 @@ public class CommandDefinition {
 	@Builder.Default
 	private boolean hide = false;
 
+	@Builder.Default
+	private boolean allowedDuringAuth = false;
+
 	@Getter
 	@ToString
 	@NoArgsConstructor

--- a/identica-api/src/main/java/me/whereareiam/identica/model/config/Messages.java
+++ b/identica-api/src/main/java/me/whereareiam/identica/model/config/Messages.java
@@ -55,6 +55,7 @@ public class Messages extends ConfigDocument {
 	@ToString
 	public static class Commands {
 		private @NotNull String currentSessionRequired;
+		private @NotNull String commandBlockedDuringAuth;
 		private @NotNull ExceptionMessages exceptions;
 		private @NotNull PaginationMessages pagination;
 		private @NotNull HelpMessages help;

--- a/identica-common/src/main/java/me/whereareiam/identica/common/CommonConfiguration.java
+++ b/identica-common/src/main/java/me/whereareiam/identica/common/CommonConfiguration.java
@@ -10,6 +10,8 @@ import me.whereareiam.configura.Config;
 import me.whereareiam.configura.type.Format;
 import me.whereareiam.identica.Registry;
 import me.whereareiam.identica.Reloadable;
+import me.whereareiam.identica.command.CommandFilterService;
+import me.whereareiam.identica.common.command.DefaultCommandFilterService;
 import me.whereareiam.identica.Serializer;
 import me.whereareiam.identica.common.adapter.ConnectionDecisionApplier;
 import me.whereareiam.identica.common.adapter.HandshakeDecisionProcessor;
@@ -215,6 +217,9 @@ public class CommonConfiguration extends AbstractModule {
 		bind(SerializerEngine.class).toProvider(SerializerEngineProvider.class);
 		Multibinder.newSetBinder(binder(), BannerContributor.class);
 		bind(Identica.class).asEagerSingleton();
+
+		// Command filtering during auth
+		bind(CommandFilterService.class).to(DefaultCommandFilterService.class).asEagerSingleton();
 	}
 
 	@Inject

--- a/identica-common/src/main/java/me/whereareiam/identica/common/command/DefaultCommandFilterService.java
+++ b/identica-common/src/main/java/me/whereareiam/identica/common/command/DefaultCommandFilterService.java
@@ -1,0 +1,103 @@
+package me.whereareiam.identica.common.command;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.whereareiam.identica.command.CommandDefinitionCollector;
+import me.whereareiam.identica.command.CommandFilterService;
+import me.whereareiam.identica.command.CommandService;
+import me.whereareiam.identica.identity.actor.Identity;
+import me.whereareiam.identica.identity.session.SessionService;
+import me.whereareiam.keystone.Actor;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+@Singleton
+public class DefaultCommandFilterService implements CommandFilterService {
+	private final SessionService sessionService;
+	private final CommandDefinitionCollector definitionCollector;
+	private final CommandService commandService;
+
+	@Inject
+	public DefaultCommandFilterService(
+			SessionService sessionService,
+			CommandDefinitionCollector definitionCollector,
+			CommandService commandService
+	) {
+		this.sessionService = sessionService;
+		this.definitionCollector = definitionCollector;
+		this.commandService = commandService;
+	}
+
+	@Override
+	public boolean isAllowed(@NotNull Actor sender, @NotNull String commandLine) {
+		if (!(sender instanceof Identity identity))
+			return true;
+
+		UUID accountUniqueId = identity.getAccountUniqueId();
+		if (accountUniqueId != null) {
+			boolean hasSession = sessionService.findByUniqueId(accountUniqueId)
+					.join()
+					.isPresent();
+			if (hasSession)
+				return true;
+		}
+
+		String normalized = normalize(commandLine);
+		if (normalized == null || normalized.isBlank())
+			return false;
+
+		Set<String> allowedAliases = definitionCollector.getAllowedDuringAuthAliases();
+		String firstWord = firstWord(normalized);
+
+		if (firstWord == null)
+			return allowedAliases.contains(normalized);
+
+		if (!allowedAliases.contains(firstWord))
+			return false;
+
+		String rest = normalized.substring(firstWord.length()).trim();
+		if (rest.isEmpty())
+			return true;
+
+		String entire = firstWord + " " + rest;
+		if (allowedAliases.contains(entire))
+			return true;
+
+		return !isKnownSubcommand(rest, allowedAliases);
+	}
+
+	private boolean isKnownSubcommand(String rest, Set<String> allowedAliases) {
+		Set<String> allAliases = new HashSet<>();
+		commandService.getRegisteredDefinitions().values().forEach(def -> {
+			if (def.getAliases() != null)
+				allAliases.addAll(def.getAliases());
+		});
+
+		for (String alias : allAliases) {
+			if (allowedAliases.contains(alias))
+				continue;
+			if (rest.equals(alias) || rest.startsWith(alias + " "))
+				return true;
+		}
+		return false;
+	}
+
+	private String normalize(String commandLine) {
+		if (commandLine == null || commandLine.isBlank())
+			return null;
+
+		String trimmed = commandLine.trim();
+		if (trimmed.startsWith("/"))
+			trimmed = trimmed.substring(1);
+
+		return trimmed;
+	}
+
+	private String firstWord(String normalized) {
+		int spaceIndex = normalized.indexOf(' ');
+		return spaceIndex > 0 ? normalized.substring(0, spaceIndex) : null;
+	}
+}

--- a/identica-common/src/main/java/me/whereareiam/identica/common/config/defaults/commands/CoreCommandDefinitions.java
+++ b/identica-common/src/main/java/me/whereareiam/identica/common/config/defaults/commands/CoreCommandDefinitions.java
@@ -17,6 +17,7 @@ public class CoreCommandDefinitions implements CommandDefinitions {
 				.usage("{alias}")
 				.cooldown(globalCooldown())
 				.hide(true)
+				.allowedDuringAuth(true)
 				.build());
 
 		registry.register("help", CommandDefinition.builder()
@@ -37,6 +38,7 @@ public class CoreCommandDefinitions implements CommandDefinitions {
 				.usage("{command} {alias} <eligibility>")
 				.arguments(Map.of("eligibility", "Provider id"))
 				.hide(true)
+				.allowedDuringAuth(true)
 				.build());
 
 		registry.register("availability-username", CommandDefinition.builder()

--- a/identica-common/src/main/java/me/whereareiam/identica/common/config/defaults/commands/VerificationCommandDefinitions.java
+++ b/identica-common/src/main/java/me/whereareiam/identica/common/config/defaults/commands/VerificationCommandDefinitions.java
@@ -13,9 +13,12 @@ public class VerificationCommandDefinitions implements CommandDefinitions {
 				"verification",
 				base("2fa", "Verification methods", "{alias}").toBuilder()
 				.hide(true)
+				.allowedDuringAuth(true)
 				.build()
 		);
-		registry.register("verification-status", base("2fa status", "Show verification status", "{alias}"));
+		registry.register("verification-status", base("2fa status", "Show verification status", "{alias}").toBuilder()
+				.allowedDuringAuth(true)
+				.build());
 		registry.register(
 				"verification-enroll",
 				withArguments(
@@ -23,7 +26,9 @@ public class VerificationCommandDefinitions implements CommandDefinitions {
 						"Start verification method enrollment",
 						"{alias} <method>",
 						Map.of("method", "Method id")
-				)
+				).toBuilder()
+				.allowedDuringAuth(true)
+				.build()
 		);
 		registry.register(
 				"verification-confirm",
@@ -34,6 +39,7 @@ public class VerificationCommandDefinitions implements CommandDefinitions {
 						Map.of("input", "Verification code")
 				).toBuilder()
 				.hide(true)
+				.allowedDuringAuth(true)
 				.build()
 		);
 		registry.register(
@@ -45,6 +51,7 @@ public class VerificationCommandDefinitions implements CommandDefinitions {
 						Map.of("input", "Code or saved")
 				).toBuilder()
 				.hide(true)
+				.allowedDuringAuth(true)
 				.build()
 		);
 		registry.register(
@@ -54,7 +61,9 @@ public class VerificationCommandDefinitions implements CommandDefinitions {
 						"Select a verification method for a provider",
 						"{alias} <provider> <method>",
 						Map.of("provider", "Provider id", "method", "Method id")
-				)
+				).toBuilder()
+				.allowedDuringAuth(true)
+				.build()
 		);
 		registry.register(
 				"verification-disable",
@@ -63,12 +72,15 @@ public class VerificationCommandDefinitions implements CommandDefinitions {
 						"Disable an enrolled verification method",
 						"{alias} <method>",
 						Map.of("method", "Method id")
-				)
+				).toBuilder()
+				.allowedDuringAuth(true)
+				.build()
 		);
 		registry.register(
 				"verification-enroll-cancel",
 				base("2fa enroll cancel", "Cancel pending verification enrollment", "{alias}").toBuilder()
 				.hide(true)
+				.allowedDuringAuth(true)
 				.build()
 		);
 	}

--- a/identica-common/src/main/java/me/whereareiam/identica/common/config/defaults/messages/MessagesCommandDefaults.java
+++ b/identica-common/src/main/java/me/whereareiam/identica/common/config/defaults/messages/MessagesCommandDefaults.java
@@ -12,6 +12,7 @@ import java.util.List;
 public class MessagesCommandDefaults {
 	public Messages.Commands supply(Messages.Commands commands) {
 		commands.setCurrentSessionRequired("{prefix}<white>You must have an <red>active session</red> to use this command.</white>");
+		commands.setCommandBlockedDuringAuth("{prefix}<white>You must <red>authenticate</red> before using this command.</white>");
 		applyExceptions(commands);
 		applyPagination(commands);
 		applyHelp(commands);

--- a/identica-common/src/test/java/me/whereareiam/identica/common/command/DefaultCommandFilterServiceTest.java
+++ b/identica-common/src/test/java/me/whereareiam/identica/common/command/DefaultCommandFilterServiceTest.java
@@ -1,0 +1,146 @@
+package me.whereareiam.identica.common.command;
+
+import me.whereareiam.identica.command.CommandDefinitionCollector;
+import me.whereareiam.identica.command.CommandService;
+import me.whereareiam.identica.identity.actor.Identity;
+import me.whereareiam.identica.identity.session.SessionService;
+import me.whereareiam.identica.model.Session;
+import me.whereareiam.keystone.Actor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("Default Command Filter Service")
+class DefaultCommandFilterServiceTest {
+	private final SessionService sessionService = mock(SessionService.class);
+	private final CommandDefinitionCollector definitionCollector = mock(CommandDefinitionCollector.class);
+	private final CommandService commandService = mock(CommandService.class);
+	private final DefaultCommandFilterService service = new DefaultCommandFilterService(sessionService, definitionCollector, commandService);
+
+	@DisplayName("Allows non-Identity actors (console)")
+	@Test
+	void allowsNonIdentityActors() {
+		Actor console = mock(Actor.class);
+
+		assertTrue(service.isAllowed(console, "/somecommand"));
+	}
+
+	@DisplayName("Allows identity with active session")
+	@Test
+	void allowsIdentityWithActiveSession() {
+		UUID accountId = UUID.randomUUID();
+		Identity identity = mock(Identity.class);
+		when(identity.getAccountUniqueId()).thenReturn(accountId);
+		when(sessionService.findByUniqueId(accountId)).thenReturn(CompletableFuture.completedFuture(Optional.of(mock(Session.class))));
+
+		assertTrue(service.isAllowed(identity, "/somecommand"));
+	}
+
+	@DisplayName("Allows identity with null accountUniqueId when command is whitelisted")
+	@Test
+	void allowsIdentityWithNullAccountAndWhitelistedCommand() {
+		Identity identity = mock(Identity.class);
+		when(identity.getAccountUniqueId()).thenReturn(null);
+		when(definitionCollector.getAllowedDuringAuthAliases()).thenReturn(Set.of("login"));
+
+		assertTrue(service.isAllowed(identity, "/login"));
+	}
+
+	@DisplayName("Denies identity with null accountUniqueId when command is not whitelisted")
+	@Test
+	void deniesIdentityWithNullAccountAndNonWhitelistedCommand() {
+		Identity identity = mock(Identity.class);
+		when(identity.getAccountUniqueId()).thenReturn(null);
+		when(definitionCollector.getAllowedDuringAuthAliases()).thenReturn(Set.of("login"));
+
+		assertFalse(service.isAllowed(identity, "/tp"));
+	}
+
+	@DisplayName("Denies identity without session when command is not whitelisted")
+	@Test
+	void deniesIdentityWithoutSessionAndNonWhitelistedCommand() {
+		UUID accountId = UUID.randomUUID();
+		Identity identity = mock(Identity.class);
+		when(identity.getAccountUniqueId()).thenReturn(accountId);
+		when(sessionService.findByUniqueId(accountId)).thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+		when(definitionCollector.getAllowedDuringAuthAliases()).thenReturn(Set.of("login"));
+
+		assertFalse(service.isAllowed(identity, "/tp"));
+	}
+
+	@DisplayName("Handles command with subcommands by checking only the first word")
+	@Test
+	void handlesSubcommandByCheckingFirstWord() {
+		Identity identity = mock(Identity.class);
+		when(identity.getAccountUniqueId()).thenReturn(null);
+		when(definitionCollector.getAllowedDuringAuthAliases()).thenReturn(Set.of("2fa"));
+		when(commandService.getRegisteredDefinitions()).thenReturn(new HashMap<>());
+
+		assertTrue(service.isAllowed(identity, "/2fa enroll totp"));
+		assertTrue(service.isAllowed(identity, "/2fa status"));
+		assertFalse(service.isAllowed(identity, "/other subcommand"));
+	}
+
+	@DisplayName("Handles command without leading slash")
+	@Test
+	void handlesCommandWithoutSlash() {
+		Identity identity = mock(Identity.class);
+		when(identity.getAccountUniqueId()).thenReturn(null);
+		when(definitionCollector.getAllowedDuringAuthAliases()).thenReturn(Set.of("login"));
+		when(commandService.getRegisteredDefinitions()).thenReturn(new HashMap<>());
+
+		assertTrue(service.isAllowed(identity, "login password123"));
+	}
+
+	@DisplayName("Returns false for blank command line")
+	@Test
+	void deniesBlankCommandLine() {
+		Identity identity = mock(Identity.class);
+		when(identity.getAccountUniqueId()).thenReturn(null);
+
+		assertFalse(service.isAllowed(identity, ""));
+		assertFalse(service.isAllowed(identity, " "));
+	}
+
+	@DisplayName("Returns false for null command line")
+	@Test
+	@SuppressWarnings("DataFlowIssue")
+	void deniesNullCommandLine() {
+		Identity identity = mock(Identity.class);
+		when(identity.getAccountUniqueId()).thenReturn(null);
+
+		assertFalse(service.isAllowed(identity, null));
+	}
+
+	@DisplayName("Checks session only when accountUniqueId is not null")
+	@Test
+	void doesNotCheckSessionWhenAccountUniqueIdIsNull() {
+		Identity identity = mock(Identity.class);
+		when(identity.getAccountUniqueId()).thenReturn(null);
+		when(definitionCollector.getAllowedDuringAuthAliases()).thenReturn(Set.of("login"));
+
+		assertTrue(service.isAllowed(identity, "/login"));
+	}
+
+	@DisplayName("Denies when session lookup fails and command is not whitelisted")
+	@Test
+	void deniesWhenSessionMissingAndCommandNotWhitelisted() {
+		UUID accountId = UUID.randomUUID();
+		Identity identity = mock(Identity.class);
+		when(identity.getAccountUniqueId()).thenReturn(accountId);
+		when(sessionService.findByUniqueId(accountId)).thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+		when(definitionCollector.getAllowedDuringAuthAliases()).thenReturn(Set.of());
+
+		assertFalse(service.isAllowed(identity, "/anycommand"));
+	}
+}

--- a/identica-platform/platform-bungeecord/bootstrap/src/main/java/me/whereareiam/identica/platform/bungeecord/listener/BungeeCordListenerRegistrar.java
+++ b/identica-platform/platform-bungeecord/bootstrap/src/main/java/me/whereareiam/identica/platform/bungeecord/listener/BungeeCordListenerRegistrar.java
@@ -8,7 +8,10 @@ import me.whereareiam.identica.common.CommonListenerRegistrar;
 import me.whereareiam.identica.listener.DynamicListener;
 import me.whereareiam.identica.listener.DynamicListenerRegistry;
 import me.whereareiam.identica.model.config.Settings;
+import me.whereareiam.identica.type.event.EventPriority;
 import me.whereareiam.identica.platform.bungeecord.BungeeCordIdentica;
+import me.whereareiam.identica.platform.bungeecord.listener.command.CommandBlockerListener;
+import me.whereareiam.identica.platform.bungeecord.listener.command.TabCompleteFilterListener;
 import me.whereareiam.identica.platform.bungeecord.listener.connection.LoginListener;
 import me.whereareiam.identica.platform.bungeecord.listener.connection.PlayerDisconnectListener;
 import me.whereareiam.identica.platform.bungeecord.listener.connection.PostLoginListener;
@@ -49,6 +52,8 @@ public class BungeeCordListenerRegistrar extends CommonListenerRegistrar {
 		registerListener(ServerSwitchEvent.class, injector.getInstance(ServerSwitchListener.class));
 		registerListener(ServerConnectEvent.class, injector.getInstance(ServerConnectListener.class));
 		registerListener(PlayerDisconnectEvent.class, injector.getInstance(PlayerDisconnectListener.class));
+		dynamicListenerRegistrar.register(ChatEvent.class, injector.getInstance(CommandBlockerListener.class), EventPriority.HIGHEST);
+		dynamicListenerRegistrar.register(TabCompleteEvent.class, injector.getInstance(TabCompleteFilterListener.class), EventPriority.HIGHEST);
 	}
 
 	@Override

--- a/identica-platform/platform-bungeecord/bootstrap/src/main/java/me/whereareiam/identica/platform/bungeecord/listener/DynamicListenerRegistrar.java
+++ b/identica-platform/platform-bungeecord/bootstrap/src/main/java/me/whereareiam/identica/platform/bungeecord/listener/DynamicListenerRegistrar.java
@@ -63,6 +63,16 @@ public class DynamicListenerRegistrar {
 		});
 	}
 
+	public <T> void register(@NotNull Class<T> eventClass, @NotNull DynamicListener<T> listener, @NotNull EventPriority priority) {
+		if (shouldSkip(eventClass)) return;
+
+		Logger.debug("Registering listener for event " + eventClass.getName() + " with priority " + priority);
+		registrations.computeIfAbsent(new RegistrationKey(listener, eventClass), ignored -> {
+			registerReflective(eventClass, listener, BungeeCordEventPriority.of(priority));
+			return Boolean.TRUE;
+		});
+	}
+
 	private boolean shouldSkip(@NotNull Class<?> eventClass) {
 		var registration = settings
 				.get()
@@ -89,8 +99,11 @@ public class DynamicListenerRegistrar {
 	}
 
 	private <T> void registerReflective(@NotNull Class<T> eventClass, @NotNull DynamicListener<T> listener) {
+		registerReflective(eventClass, listener, BungeeCordEventPriority.of(determinePriority(eventClass)));
+	}
+
+	private <T> void registerReflective(@NotNull Class<T> eventClass, @NotNull DynamicListener<T> listener, byte priority) {
 		Method handler = resolveHandlerMethod(listener, eventClass);
-		byte priority = BungeeCordEventPriority.of(determinePriority(eventClass));
 
 		eventBusLock.lock();
 		try {

--- a/identica-platform/platform-bungeecord/bootstrap/src/main/java/me/whereareiam/identica/platform/bungeecord/listener/command/CommandBlockerListener.java
+++ b/identica-platform/platform-bungeecord/bootstrap/src/main/java/me/whereareiam/identica/platform/bungeecord/listener/command/CommandBlockerListener.java
@@ -1,0 +1,64 @@
+package me.whereareiam.identica.platform.bungeecord.listener.command;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.inject.Singleton;
+import me.whereareiam.identica.Serializer;
+import me.whereareiam.identica.command.CommandFilterService;
+import me.whereareiam.identica.identity.IdentityService;
+import me.whereareiam.identica.identity.actor.Identity;
+import me.whereareiam.identica.listener.DynamicListener;
+import me.whereareiam.identica.model.config.Messages;
+import me.whereareiam.keystone.model.SerializerContent;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.event.ChatEvent;
+import org.jetbrains.annotations.NotNull;
+
+@Singleton
+public class CommandBlockerListener implements DynamicListener<ChatEvent> {
+	private final CommandFilterService commandFilterService;
+	private final IdentityService identityService;
+	private final Provider<Messages> messagesProvider;
+
+	@Inject
+	public CommandBlockerListener(
+			CommandFilterService commandFilterService,
+			IdentityService identityService,
+			Provider<Messages> messagesProvider
+	) {
+		this.commandFilterService = commandFilterService;
+		this.identityService = identityService;
+		this.messagesProvider = messagesProvider;
+	}
+
+	@Override
+	public void onEvent(@NotNull ChatEvent event) {
+		if (!event.isCommand())
+			return;
+
+		if (!(event.getSender() instanceof ProxiedPlayer player))
+			return;
+
+		String message = event.getMessage();
+		if (message == null || message.isBlank())
+			return;
+
+		Identity identity = identityService.findByConnectionUniqueId(player.getUniqueId()).orElse(null);
+		if (identity == null)
+			return;
+
+		if (commandFilterService.isAllowed(identity, message))
+			return;
+
+		event.setCancelled(true);
+
+		String blockedMessage = messagesProvider.get().getCommands().getCommandBlockedDuringAuth();
+		if (!blockedMessage.isBlank()) {
+			SerializerContent content = SerializerContent.builder()
+					.receiver(identity)
+					.message(blockedMessage)
+					.build();
+			identity.sendMessage(Serializer.serialize(content));
+		}
+	}
+}

--- a/identica-platform/platform-bungeecord/bootstrap/src/main/java/me/whereareiam/identica/platform/bungeecord/listener/command/TabCompleteFilterListener.java
+++ b/identica-platform/platform-bungeecord/bootstrap/src/main/java/me/whereareiam/identica/platform/bungeecord/listener/command/TabCompleteFilterListener.java
@@ -1,0 +1,83 @@
+package me.whereareiam.identica.platform.bungeecord.listener.command;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.whereareiam.identica.command.CommandDefinitionCollector;
+import me.whereareiam.identica.command.CommandService;
+import me.whereareiam.identica.identity.IdentityService;
+import me.whereareiam.identica.identity.actor.Identity;
+import me.whereareiam.identica.identity.session.SessionService;
+import me.whereareiam.identica.listener.DynamicListener;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.event.TabCompleteEvent;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+@Singleton
+public class TabCompleteFilterListener implements DynamicListener<TabCompleteEvent> {
+	private final IdentityService identityService;
+	private final SessionService sessionService;
+	private final CommandDefinitionCollector definitionCollector;
+	private final CommandService commandService;
+
+	@Inject
+	public TabCompleteFilterListener(
+			IdentityService identityService,
+			SessionService sessionService,
+			CommandDefinitionCollector definitionCollector,
+			CommandService commandService
+	) {
+		this.identityService = identityService;
+		this.sessionService = sessionService;
+		this.definitionCollector = definitionCollector;
+		this.commandService = commandService;
+	}
+
+	@Override
+	public void onEvent(@NotNull TabCompleteEvent event) {
+		if (!(event.getSender() instanceof ProxiedPlayer player))
+			return;
+
+		Identity identity = identityService.findByConnectionUniqueId(player.getUniqueId()).orElse(null);
+		if (identity != null && isAuthenticated(identity)) return;
+
+		Set<String> allowedAliases = definitionCollector.getAllowedDuringAuthAliases();
+		Set<String> allAliases = new HashSet<>();
+		commandService.getRegisteredDefinitions().values().forEach(def -> {
+			if (def.getAliases() != null)
+				allAliases.addAll(def.getAliases());
+		});
+
+		event.getSuggestions().removeIf(suggestion -> {
+			if (suggestion == null || suggestion.isBlank()) return true;
+			String trimmed = suggestion.startsWith("/") ? suggestion.substring(1) : suggestion;
+			int spaceIndex = trimmed.indexOf(' ');
+			String firstWord = spaceIndex > 0 ? trimmed.substring(0, spaceIndex) : trimmed;
+
+			if (allowedAliases.contains(firstWord)) {
+				if (spaceIndex < 0)
+					return false;
+				String remaining = trimmed.substring(firstWord.length()).trim();
+				if (remaining.isEmpty())
+					return false;
+				if (allowedAliases.contains(remaining) || allowedAliases.contains(trimmed))
+					return false;
+				for (String alias : allAliases) {
+					if (alias.equals(remaining) || alias.startsWith(remaining + " ") || remaining.startsWith(alias + " "))
+						return true;
+				}
+				return false;
+			}
+			return true;
+		});
+	}
+
+	private boolean isAuthenticated(Identity identity) {
+		UUID accountUniqueId = identity.getAccountUniqueId();
+		if (accountUniqueId == null) return false;
+		return sessionService.findByUniqueId(accountUniqueId).join().isPresent();
+	}
+}

--- a/identica-platform/platform-bungeecord/bootstrap/src/test/java/me/whereareiam/identica/platform/bungeecord/listener/command/TabCompleteFilterListenerTest.java
+++ b/identica-platform/platform-bungeecord/bootstrap/src/test/java/me/whereareiam/identica/platform/bungeecord/listener/command/TabCompleteFilterListenerTest.java
@@ -1,0 +1,184 @@
+package me.whereareiam.identica.platform.bungeecord.listener.command;
+
+import me.whereareiam.identica.command.CommandDefinitionCollector;
+import me.whereareiam.identica.command.CommandService;
+import me.whereareiam.identica.identity.IdentityService;
+import me.whereareiam.identica.identity.actor.Identity;
+import me.whereareiam.identica.identity.session.SessionService;
+import me.whereareiam.identica.model.Session;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.event.TabCompleteEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("BungeeCord Tab Complete Filter Listener")
+class TabCompleteFilterListenerTest {
+	private final IdentityService identityService = mock(IdentityService.class);
+	private final SessionService sessionService = mock(SessionService.class);
+	private final CommandDefinitionCollector definitionCollector = mock(CommandDefinitionCollector.class);
+	private final CommandService commandService = mock(CommandService.class);
+	private final TabCompleteFilterListener listener = new TabCompleteFilterListener(identityService, sessionService, definitionCollector, commandService);
+
+	@DisplayName("Does not filter for authenticated players")
+	@Test
+	void doesNotFilterForAuthenticatedPlayers() {
+		UUID playerId = UUID.randomUUID();
+		UUID accountId = UUID.randomUUID();
+		ProxiedPlayer player = mock(ProxiedPlayer.class);
+		when(player.getUniqueId()).thenReturn(playerId);
+
+		Identity identity = mock(Identity.class);
+		when(identity.getAccountUniqueId()).thenReturn(accountId);
+		when(identityService.findByConnectionUniqueId(playerId)).thenReturn(Optional.of(identity));
+		when(sessionService.findByUniqueId(accountId)).thenReturn(CompletableFuture.completedFuture(Optional.of(mock(Session.class))));
+
+		TabCompleteEvent event = mock(TabCompleteEvent.class);
+		when(event.getSender()).thenReturn(player);
+		List<String> suggestions = new ArrayList<>(List.of("/tp", "/gamemode"));
+		when(event.getSuggestions()).thenReturn(suggestions);
+
+		listener.onEvent(event);
+
+		assertEquals(List.of("/tp", "/gamemode"), suggestions);
+	}
+
+	@DisplayName("Does nothing when sender is not a ProxiedPlayer")
+	@Test
+	void doesNothingWhenNotProxiedPlayer() {
+		TabCompleteEvent event = mock(TabCompleteEvent.class);
+		net.md_5.bungee.api.CommandSender sender = mock(net.md_5.bungee.api.CommandSender.class);
+		doReturn(sender).when(event).getSender();
+
+		listener.onEvent(event);
+	}
+
+	@DisplayName("Filters suggestions when identity is not found")
+	@Test
+	void filtersSuggestionsWhenIdentityNotFound() {
+		UUID playerId = UUID.randomUUID();
+		ProxiedPlayer player = mock(ProxiedPlayer.class);
+		when(player.getUniqueId()).thenReturn(playerId);
+
+		when(identityService.findByConnectionUniqueId(playerId)).thenReturn(Optional.empty());
+		when(definitionCollector.getAllowedDuringAuthAliases()).thenReturn(Set.of("login"));
+		when(commandService.getRegisteredDefinitions()).thenReturn(new HashMap<>());
+
+		TabCompleteEvent event = mock(TabCompleteEvent.class);
+		when(event.getSender()).thenReturn(player);
+		List<String> suggestions = new ArrayList<>(List.of("/login", "/tp"));
+		when(event.getSuggestions()).thenReturn(suggestions);
+
+		listener.onEvent(event);
+
+		assertEquals(List.of("/login"), suggestions);
+	}
+
+	@DisplayName("Filters suggestions for unauthenticated players")
+	@Test
+	void filtersSuggestionsForUnauthenticatedPlayers() {
+		UUID playerId = UUID.randomUUID();
+		ProxiedPlayer player = mock(ProxiedPlayer.class);
+		when(player.getUniqueId()).thenReturn(playerId);
+
+		Identity identity = mock(Identity.class);
+		when(identity.getAccountUniqueId()).thenReturn(null);
+		when(identityService.findByConnectionUniqueId(playerId)).thenReturn(Optional.of(identity));
+		when(definitionCollector.getAllowedDuringAuthAliases()).thenReturn(Set.of("login", "auth"));
+		when(commandService.getRegisteredDefinitions()).thenReturn(new HashMap<>());
+
+		TabCompleteEvent event = mock(TabCompleteEvent.class);
+		when(event.getSender()).thenReturn(player);
+		List<String> suggestions = new ArrayList<>(List.of("/login", "/tp", "/gamemode", "/auth"));
+		when(event.getSuggestions()).thenReturn(suggestions);
+
+		listener.onEvent(event);
+
+		assertEquals(List.of("/login", "/auth"), suggestions);
+	}
+
+	@DisplayName("Removes suggestions without leading slash")
+	@Test
+	void handlesSuggestionsWithoutLeadingSlash() {
+		UUID playerId = UUID.randomUUID();
+		ProxiedPlayer player = mock(ProxiedPlayer.class);
+		when(player.getUniqueId()).thenReturn(playerId);
+
+		Identity identity = mock(Identity.class);
+		when(identity.getAccountUniqueId()).thenReturn(null);
+		when(identityService.findByConnectionUniqueId(playerId)).thenReturn(Optional.of(identity));
+		when(definitionCollector.getAllowedDuringAuthAliases()).thenReturn(Set.of("login"));
+		when(commandService.getRegisteredDefinitions()).thenReturn(new HashMap<>());
+
+		TabCompleteEvent event = mock(TabCompleteEvent.class);
+		when(event.getSender()).thenReturn(player);
+		List<String> suggestions = new ArrayList<>(List.of("login", "tp"));
+		when(event.getSuggestions()).thenReturn(suggestions);
+
+		listener.onEvent(event);
+
+		assertEquals(List.of("login"), suggestions);
+	}
+
+	@DisplayName("Filters multi-word aliases by first word")
+	@Test
+	void filtersMultiWordAliasesByFirstWord() {
+		UUID playerId = UUID.randomUUID();
+		ProxiedPlayer player = mock(ProxiedPlayer.class);
+		when(player.getUniqueId()).thenReturn(playerId);
+
+		Identity identity = mock(Identity.class);
+		when(identity.getAccountUniqueId()).thenReturn(null);
+		when(identityService.findByConnectionUniqueId(playerId)).thenReturn(Optional.of(identity));
+		when(definitionCollector.getAllowedDuringAuthAliases()).thenReturn(Set.of("credential confirm", "credential cancel"));
+		when(commandService.getRegisteredDefinitions()).thenReturn(new HashMap<>());
+
+		TabCompleteEvent event = mock(TabCompleteEvent.class);
+		when(event.getSender()).thenReturn(player);
+		List<String> suggestions = new ArrayList<>(List.of("/credential", "/tp"));
+		when(event.getSuggestions()).thenReturn(suggestions);
+
+		listener.onEvent(event);
+
+		assertEquals(List.of("/credential"), suggestions);
+	}
+
+	@DisplayName("Removes null and blank suggestions")
+	@Test
+	void removesNullAndBlankSuggestions() {
+		UUID playerId = UUID.randomUUID();
+		ProxiedPlayer player = mock(ProxiedPlayer.class);
+		when(player.getUniqueId()).thenReturn(playerId);
+
+		Identity identity = mock(Identity.class);
+		when(identity.getAccountUniqueId()).thenReturn(null);
+		when(identityService.findByConnectionUniqueId(playerId)).thenReturn(Optional.of(identity));
+		when(definitionCollector.getAllowedDuringAuthAliases()).thenReturn(Set.of("login"));
+		when(commandService.getRegisteredDefinitions()).thenReturn(new HashMap<>());
+
+		TabCompleteEvent event = mock(TabCompleteEvent.class);
+		when(event.getSender()).thenReturn(player);
+		List<String> suggestions = new ArrayList<>();
+		suggestions.add(null);
+		suggestions.add(" ");
+		suggestions.add("/login");
+		suggestions.add("/tp");
+		when(event.getSuggestions()).thenReturn(suggestions);
+
+		listener.onEvent(event);
+
+		assertEquals(List.of("/login"), suggestions);
+	}
+}

--- a/identica-platform/platform-velocity/bootstrap/src/main/java/me/whereareiam/identica/platform/velocity/listener/VelocityListenerRegistrar.java
+++ b/identica-platform/platform-velocity/bootstrap/src/main/java/me/whereareiam/identica/platform/velocity/listener/VelocityListenerRegistrar.java
@@ -6,6 +6,8 @@ import com.google.inject.Provider;
 import com.google.inject.Singleton;
 import com.velocitypowered.api.event.AwaitingEventExecutor;
 import com.velocitypowered.api.event.EventManager;
+import com.velocitypowered.api.event.command.CommandExecuteEvent;
+import com.velocitypowered.api.event.command.PlayerAvailableCommandsEvent;
 import com.velocitypowered.api.event.connection.DisconnectEvent;
 import com.velocitypowered.api.event.connection.LoginEvent;
 import com.velocitypowered.api.event.connection.PreLoginEvent;
@@ -18,7 +20,10 @@ import me.whereareiam.identica.listener.DynamicListener;
 import me.whereareiam.identica.listener.DynamicListenerRegistry;
 import me.whereareiam.identica.logging.Logger;
 import me.whereareiam.identica.model.config.Settings;
+import me.whereareiam.identica.type.event.EventPriority;
 import me.whereareiam.identica.platform.velocity.VelocityIdentica;
+import me.whereareiam.identica.platform.velocity.listener.command.CommandBlockerListener;
+import me.whereareiam.identica.platform.velocity.listener.command.TabCompleteFilterListener;
 import me.whereareiam.identica.platform.velocity.listener.connection.DisconnectListener;
 import me.whereareiam.identica.platform.velocity.listener.connection.GameProfileRequestListener;
 import me.whereareiam.identica.platform.velocity.listener.connection.LoginListener;
@@ -61,6 +66,14 @@ public class VelocityListenerRegistrar extends CommonListenerRegistrar {
 		registerListener(PlayerChooseInitialServerEvent.class, injector.getInstance(PlayerChooseInitialServerListener.class));
 		registerListener(ServerPreConnectEvent.class, injector.getInstance(ServerPreConnectListener.class));
 		registerListener(DisconnectEvent.class, injector.getInstance(DisconnectListener.class));
+
+		CommandBlockerListener commandBlocker = injector.getInstance(CommandBlockerListener.class);
+		eventManager.register(plugin, CommandExecuteEvent.class, VelocityUtil.of(EventPriority.HIGHEST), commandBlocker::onEvent);
+		Logger.debug("Registered CommandBlockerListener with HIGHEST priority");
+
+		TabCompleteFilterListener tabCompleteFilter = injector.getInstance(TabCompleteFilterListener.class);
+		eventManager.register(plugin, PlayerAvailableCommandsEvent.class, VelocityUtil.of(EventPriority.HIGHEST), tabCompleteFilter::onEvent);
+		Logger.debug("Registered TabCompleteFilterListener with HIGHEST priority");
 	}
 
 	@Override

--- a/identica-platform/platform-velocity/bootstrap/src/main/java/me/whereareiam/identica/platform/velocity/listener/command/CommandBlockerListener.java
+++ b/identica-platform/platform-velocity/bootstrap/src/main/java/me/whereareiam/identica/platform/velocity/listener/command/CommandBlockerListener.java
@@ -1,0 +1,61 @@
+package me.whereareiam.identica.platform.velocity.listener.command;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.inject.Singleton;
+import com.velocitypowered.api.event.command.CommandExecuteEvent;
+import com.velocitypowered.api.proxy.Player;
+import me.whereareiam.identica.Serializer;
+import me.whereareiam.identica.command.CommandFilterService;
+import me.whereareiam.identica.identity.IdentityService;
+import me.whereareiam.identica.identity.actor.Identity;
+import me.whereareiam.identica.listener.DynamicListener;
+import me.whereareiam.identica.model.config.Messages;
+import me.whereareiam.keystone.model.SerializerContent;
+import org.jetbrains.annotations.NotNull;
+
+@Singleton
+public class CommandBlockerListener implements DynamicListener<CommandExecuteEvent> {
+	private final CommandFilterService commandFilterService;
+	private final IdentityService identityService;
+	private final Provider<Messages> messagesProvider;
+
+	@Inject
+	public CommandBlockerListener(
+			CommandFilterService commandFilterService,
+			IdentityService identityService,
+			Provider<Messages> messagesProvider
+	) {
+		this.commandFilterService = commandFilterService;
+		this.identityService = identityService;
+		this.messagesProvider = messagesProvider;
+	}
+
+	@Override
+	public void onEvent(@NotNull CommandExecuteEvent event) {
+		if (!(event.getCommandSource() instanceof Player player))
+			return;
+
+		String commandLine = event.getCommand();
+		if (commandLine == null || commandLine.isBlank())
+			return;
+
+		Identity identity = identityService.findByConnectionUniqueId(player.getUniqueId()).orElse(null);
+		if (identity == null)
+			return;
+
+		if (commandFilterService.isAllowed(identity, commandLine))
+			return;
+
+		event.setResult(CommandExecuteEvent.CommandResult.denied());
+
+		String message = messagesProvider.get().getCommands().getCommandBlockedDuringAuth();
+		if (!message.isBlank()) {
+			SerializerContent content = SerializerContent.builder()
+					.receiver(identity)
+					.message(message)
+					.build();
+			identity.sendMessage(Serializer.serialize(content));
+		}
+	}
+}

--- a/identica-platform/platform-velocity/bootstrap/src/main/java/me/whereareiam/identica/platform/velocity/listener/command/TabCompleteFilterListener.java
+++ b/identica-platform/platform-velocity/bootstrap/src/main/java/me/whereareiam/identica/platform/velocity/listener/command/TabCompleteFilterListener.java
@@ -1,0 +1,97 @@
+package me.whereareiam.identica.platform.velocity.listener.command;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.mojang.brigadier.tree.CommandNode;
+import com.mojang.brigadier.tree.LiteralCommandNode;
+import com.velocitypowered.api.event.command.PlayerAvailableCommandsEvent;
+import com.velocitypowered.api.proxy.Player;
+import me.whereareiam.identica.command.CommandDefinitionCollector;
+import me.whereareiam.identica.identity.IdentityService;
+import me.whereareiam.identica.identity.actor.Identity;
+import me.whereareiam.identica.identity.session.SessionService;
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.reflect.Field;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+@Singleton
+public class TabCompleteFilterListener {
+	private final IdentityService identityService;
+	private final SessionService sessionService;
+	private final CommandDefinitionCollector definitionCollector;
+
+	@Inject
+	public TabCompleteFilterListener(
+			IdentityService identityService,
+			SessionService sessionService,
+			CommandDefinitionCollector definitionCollector
+	) {
+		this.identityService = identityService;
+		this.sessionService = sessionService;
+		this.definitionCollector = definitionCollector;
+	}
+
+	public void onEvent(@NotNull PlayerAvailableCommandsEvent event) {
+		Player player = event.getPlayer();
+		if (player == null) return;
+
+		Identity identity = identityService.findByConnectionUniqueId(player.getUniqueId()).orElse(null);
+		if (identity != null && isAuthenticated(identity)) return;
+
+		Set<String> allowedAliases = definitionCollector.getAllowedDuringAuthAliases();
+		Set<String> allowedNames = new HashSet<>();
+		for (String alias : allowedAliases) {
+			int spaceIndex = alias.indexOf(' ');
+			allowedNames.add(spaceIndex > 0 ? alias.substring(0, spaceIndex) : alias);
+		}
+
+		try {
+			Field childrenField = CommandNode.class.getDeclaredField("children");
+			childrenField.setAccessible(true);
+			@SuppressWarnings("unchecked")
+			Map<String, CommandNode<?>> rootChildren = (Map<String, CommandNode<?>>) childrenField.get(event.getRootNode());
+			rootChildren.entrySet().removeIf(entry -> !allowedNames.contains(entry.getKey()));
+			for (Map.Entry<String, CommandNode<?>> entry : rootChildren.entrySet()) {
+				filterChildNodes(entry.getValue(), childrenField, allowedNames, allowedAliases, entry.getKey());
+			}
+		} catch (NoSuchFieldException | IllegalAccessException ignored) {
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private void filterChildNodes(CommandNode<?> node, Field childrenField, Set<String> allowedNames, Set<String> allowedAliases, String prefix) throws IllegalAccessException {
+		Map<String, CommandNode<?>> children = (Map<String, CommandNode<?>>) childrenField.get(node);
+		if (children.isEmpty()) return;
+
+		Set<String> allowedChildren = new HashSet<>(allowedNames);
+		String prefixSpace = prefix + " ";
+		for (String alias : allowedAliases) {
+			if (alias.startsWith(prefixSpace) && alias.length() > prefixSpace.length()) {
+				String rest = alias.substring(prefixSpace.length());
+				int nextSpace = rest.indexOf(' ');
+				allowedChildren.add(nextSpace > 0 ? rest.substring(0, nextSpace) : rest);
+			}
+		}
+
+		children.entrySet().removeIf(entry -> {
+			if (!(entry.getValue() instanceof LiteralCommandNode))
+				return false;
+			return !allowedChildren.contains(entry.getKey());
+		});
+
+		for (Map.Entry<String, CommandNode<?>> entry : children.entrySet()) {
+			if (entry.getValue() instanceof LiteralCommandNode)
+				filterChildNodes(entry.getValue(), childrenField, allowedNames, allowedAliases, prefix + " " + entry.getKey());
+		}
+	}
+
+	private boolean isAuthenticated(Identity identity) {
+		UUID accountUniqueId = identity.getAccountUniqueId();
+		if (accountUniqueId == null) return false;
+		return sessionService.findByUniqueId(accountUniqueId).join().isPresent();
+	}
+}

--- a/identica-platform/platform-velocity/bootstrap/src/test/java/me/whereareiam/identica/platform/velocity/listener/command/TabCompleteFilterListenerTest.java
+++ b/identica-platform/platform-velocity/bootstrap/src/test/java/me/whereareiam/identica/platform/velocity/listener/command/TabCompleteFilterListenerTest.java
@@ -1,0 +1,153 @@
+package me.whereareiam.identica.platform.velocity.listener.command;
+
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.tree.CommandNode;
+import com.mojang.brigadier.tree.RootCommandNode;
+import com.velocitypowered.api.event.command.PlayerAvailableCommandsEvent;
+import com.velocitypowered.api.proxy.Player;
+import me.whereareiam.identica.command.CommandDefinitionCollector;
+import me.whereareiam.identica.identity.IdentityService;
+import me.whereareiam.identica.identity.actor.Identity;
+import me.whereareiam.identica.identity.session.SessionService;
+import me.whereareiam.identica.model.Session;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("Velocity Tab Complete Filter Listener")
+class TabCompleteFilterListenerTest {
+	private final IdentityService identityService = mock(IdentityService.class);
+	private final SessionService sessionService = mock(SessionService.class);
+	private final CommandDefinitionCollector definitionCollector = mock(CommandDefinitionCollector.class);
+	private final TabCompleteFilterListener listener = new TabCompleteFilterListener(identityService, sessionService, definitionCollector);
+
+	@DisplayName("Does not filter commands for authenticated players")
+	@Test
+	void doesNotFilterForAuthenticatedPlayers() {
+		UUID playerId = UUID.randomUUID();
+		UUID accountId = UUID.randomUUID();
+		Player player = mock(Player.class);
+		when(player.getUniqueId()).thenReturn(playerId);
+
+		Identity identity = mock(Identity.class);
+		when(identity.getAccountUniqueId()).thenReturn(accountId);
+		when(identityService.findByConnectionUniqueId(playerId)).thenReturn(Optional.of(identity));
+		when(sessionService.findByUniqueId(accountId)).thenReturn(CompletableFuture.completedFuture(Optional.of(mock(Session.class))));
+
+		RootCommandNode<?> rootNode = root();
+		addChild(rootNode, "tp");
+
+		PlayerAvailableCommandsEvent event = mock(PlayerAvailableCommandsEvent.class);
+		when(event.getPlayer()).thenReturn(player);
+		doReturn(rootNode).when(event).getRootNode();
+
+		listener.onEvent(event);
+
+		assertEquals(1, rootNode.getChildren().size());
+	}
+
+	@DisplayName("Filters commands when identity is not found")
+	@Test
+	@SuppressWarnings("unchecked")
+	void filtersCommandsWhenIdentityNotFound() {
+		UUID playerId = UUID.randomUUID();
+		Player player = mock(Player.class);
+		when(player.getUniqueId()).thenReturn(playerId);
+		when(identityService.findByConnectionUniqueId(playerId)).thenReturn(Optional.empty());
+		when(definitionCollector.getAllowedDuringAuthAliases()).thenReturn(Set.of("login"));
+
+		RootCommandNode<?> rootNode = root();
+		addChild(rootNode, "login");
+		addChild(rootNode, "tp");
+
+		PlayerAvailableCommandsEvent event = mock(PlayerAvailableCommandsEvent.class);
+		when(event.getPlayer()).thenReturn(player);
+		doReturn(rootNode).when(event).getRootNode();
+
+		listener.onEvent(event);
+
+		Collection<CommandNode<?>> children = (Collection<CommandNode<?>>) (Collection<?>) rootNode.getChildren();
+		Set<String> names = children.stream().map(CommandNode::getName).collect(Collectors.toSet());
+		assertEquals(Set.of("login"), names);
+	}
+
+	@DisplayName("Removes non-whitelisted commands for unauthenticated players with null account")
+	@Test
+	@SuppressWarnings("unchecked")
+	void removesNonWhitelistedCommandsForNullAccount() {
+		UUID playerId = UUID.randomUUID();
+		Player player = mock(Player.class);
+		when(player.getUniqueId()).thenReturn(playerId);
+
+		Identity identity = mock(Identity.class);
+		when(identity.getAccountUniqueId()).thenReturn(null);
+		when(identityService.findByConnectionUniqueId(playerId)).thenReturn(Optional.of(identity));
+		when(definitionCollector.getAllowedDuringAuthAliases()).thenReturn(Set.of("login", "auth"));
+
+		RootCommandNode<?> rootNode = root();
+		addChild(rootNode, "login");
+		addChild(rootNode, "tp");
+		addChild(rootNode, "gamemode");
+		addChild(rootNode, "auth");
+
+		PlayerAvailableCommandsEvent event = mock(PlayerAvailableCommandsEvent.class);
+		when(event.getPlayer()).thenReturn(player);
+		doReturn(rootNode).when(event).getRootNode();
+
+		listener.onEvent(event);
+
+		@SuppressWarnings("unchecked")
+		Collection<CommandNode<?>> children = (Collection<CommandNode<?>>) (Collection<?>) rootNode.getChildren();
+		Set<String> names = children.stream().map(CommandNode::getName).collect(Collectors.toSet());
+		assertEquals(Set.of("login", "auth"), names);
+	}
+
+	@DisplayName("Removes non-whitelisted commands for unauthenticated players without session")
+	@Test
+	@SuppressWarnings("unchecked")
+	void removesNonWhitelistedCommandsWhenNoSession() {
+		UUID playerId = UUID.randomUUID();
+		UUID accountId = UUID.randomUUID();
+		Player player = mock(Player.class);
+		when(player.getUniqueId()).thenReturn(playerId);
+
+		Identity identity = mock(Identity.class);
+		when(identity.getAccountUniqueId()).thenReturn(accountId);
+		when(identityService.findByConnectionUniqueId(playerId)).thenReturn(Optional.of(identity));
+		when(sessionService.findByUniqueId(accountId)).thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+		when(definitionCollector.getAllowedDuringAuthAliases()).thenReturn(Set.of("2fa"));
+
+		RootCommandNode<?> rootNode = root();
+		addChild(rootNode, "2fa");
+		addChild(rootNode, "ban");
+
+		PlayerAvailableCommandsEvent event = mock(PlayerAvailableCommandsEvent.class);
+		when(event.getPlayer()).thenReturn(player);
+		doReturn(rootNode).when(event).getRootNode();
+
+		listener.onEvent(event);
+
+		Collection<CommandNode<?>> children = (Collection<CommandNode<?>>) (Collection<?>) rootNode.getChildren();
+		assertTrue(children.stream().allMatch(n -> n.getName().equals("2fa")));
+	}
+
+	private static <S> RootCommandNode<S> root() {
+		return new RootCommandNode<>();
+	}
+
+	private static <S> void addChild(RootCommandNode<S> root, String name) {
+		root.addChild(LiteralArgumentBuilder.<S>literal(name).build());
+	}
+}

--- a/identica-provider/provider-credential/credential-common/src/main/java/me/whereareiam/identica/provider/credential/config/defaults/CredentialCommandsDefaults.java
+++ b/identica-provider/provider-credential/credential-common/src/main/java/me/whereareiam/identica/provider/credential/config/defaults/CredentialCommandsDefaults.java
@@ -18,6 +18,7 @@ public class CredentialCommandsDefaults implements MergeDefaultsProvider<Credent
 				.permission("")
 				.description("Register a credential account")
 				.usage("{alias} <password>")
+				.allowedDuringAuth(true)
 				.cooldown(CommandDefinition.Cooldown.builder()
 						.enabled(true)
 						.duration(2)
@@ -34,6 +35,7 @@ public class CredentialCommandsDefaults implements MergeDefaultsProvider<Credent
 				.permission("")
 				.description("Confirm credential registration")
 				.usage("{alias} <password>")
+				.allowedDuringAuth(true)
 				.cooldown(CommandDefinition.Cooldown.builder()
 						.enabled(true)
 						.duration(2)
@@ -50,6 +52,7 @@ public class CredentialCommandsDefaults implements MergeDefaultsProvider<Credent
 				.permission("")
 				.description("Login to a credential account")
 				.usage("{alias} <password>")
+				.allowedDuringAuth(true)
 				.cooldown(CommandDefinition.Cooldown.builder()
 						.enabled(true)
 						.duration(2)
@@ -87,6 +90,7 @@ public class CredentialCommandsDefaults implements MergeDefaultsProvider<Credent
 						.group("global")
 						.build()
 				)
+				.allowedDuringAuth(true)
 				.build();
 
 		CommandDefinition credentialConfirm = CommandDefinition.builder()
@@ -97,6 +101,7 @@ public class CredentialCommandsDefaults implements MergeDefaultsProvider<Credent
 				.usage("{alias} [input]")
 				.arguments(Map.of("input", "Code"))
 				.hide(true)
+				.allowedDuringAuth(true)
 				.build();
 
 		CommandDefinition credentialCancel = CommandDefinition.builder()
@@ -106,6 +111,7 @@ public class CredentialCommandsDefaults implements MergeDefaultsProvider<Credent
 				.description("Cancel credential migration")
 				.usage("{alias}")
 				.hide(true)
+				.allowedDuringAuth(true)
 				.build();
 
 		CommandDefinition adminForceRegister = CommandDefinition.builder()


### PR DESCRIPTION
**Description:**
This Pull Request introduces a foundational mechanism to restrict command usage for players who have not yet completed the authentication process. A collector has been implemented to filter allowed commands and cache them to improve performance.

**Key changes:**
* **Added `DefaultCommandDefinitionCollector`:** Implements command collection logic (via `CommandService`). This component extracts the aliases of commands that have the `allowedDuringAuth` flag set to true, and automatically permits the use of the `"main"` system command.
* **Thread-safe Caching:** To avoid redundant computations during each check, a thread-safe caching mechanism for the list of allowed aliases (`cachedAliases`) has been implemented. An `invalidateCache()` method was also added to reset the cache (e.g., during a plugin reload).
* **Dependency Injection (DI):** The new component is registered in the `CommandConfiguration` module using Guice (`asEagerSingleton`).
* **Testing:** Added unit tests (`DefaultCommandDefinitionCollectorTest`) using JUnit 5 and Mockito to verify the correct filtering of aliases and the overall functionality of the collector.

**Tested environment:**
* Successfully tested on **Velocity** alongside **CommandWhitelist** and **LuckPerms**.